### PR TITLE
chore: upgrade GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache Yarn
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -23,13 +23,13 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Cache Haxe
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ${{ startsWith(runner.os, 'windows') && '%AppData%' || '~/haxe' }}
           key: ${{ runner.os }}-haxe
       
       - name: Cache Maven
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -37,13 +37,17 @@ jobs:
             ${{ runner.os }}-maven-
       
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: '11'
           distribution: 'adopt'
           
       - name: Set up Lix
-        uses: lix-pm/setup-lix@master
+        run: |
+          npm config set prefix "$HOME/.npm-global"
+          npm install -g lix
+          echo "$HOME/.npm-global/bin" >> "$GITHUB_PATH"
+          echo "$HOME/haxe" >> "$GITHUB_PATH"
         
       - name: Install Haxe
         run: lix download
@@ -52,7 +56,7 @@ jobs:
         run: mvn compile package
         
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: target/keycloak-webhook-event-listener-*.jar


### PR DESCRIPTION
## Summary

- upgrade GitHub Actions dependency versions
- replace deprecated workflow helpers where needed
- keep workflow behavior unchanged

## Notes

- generated from the prepared local branch under `/Users/ike/Code/github.com/beeinventor.com/github-actions`
